### PR TITLE
generate metrics for rpc sub, generate sarif format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /blib
 /Makefile
 /pm_to_blib
+/.vscode/
 
 /carton.lock
 /.carton/

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.008001';
+requires 'perl', '5.36';
 
 requires 'Carp';
 requires 'File::Basename';

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.36';
+requires 'perl', '5.008001';
 
 requires 'Carp';
 requires 'File::Basename';

--- a/lib/Perl/Metrics/Lite/Analysis/File.pm
+++ b/lib/Perl/Metrics/Lite/Analysis/File.pm
@@ -51,7 +51,14 @@ sub _init {
         = Perl::Metrics::Lite::Analysis::Util::get_packages($document);
 
     my @sub_analysis = ();
-    my $sub_elements = $document->find('PPI::Statement::Sub');
+    #my $sub_elements = $document->find('PPI::Statement::Sub');
+    my $sub_elements = $document->find(sub {
+         return '' unless $_[1]->parent == $_[0] 
+            and 
+            ($_[1]->isa('PPI::Statement::Sub') 
+            or ($_[1]->isa('PPI::Statement') and $_[1]{children}[0]{content} eq 'rpc')
+            );
+    });
     @sub_analysis = @{ $self->analyze_subs($sub_elements) };
 
     $_MAIN_STATS{$self} = $self->analyze_file($document);
@@ -155,6 +162,7 @@ sub analyze_subs {
         !Perl::Metrics::Lite::Analysis::Util::is_ref( $found_subs, 'ARRAY' )
         );
 
+    $found_subs = $self->replace_rpc_with_sub($found_subs);
     my @subs = ();
     foreach my $sub ( @{$found_subs} ) {
         my $metrics = $self->measure_sub_metrics($sub);
@@ -162,6 +170,30 @@ sub analyze_subs {
         push @subs, $metrics;
     }
     return \@subs;
+}
+
+sub  replace_rpc_with_sub {
+    my ( $self, $found_subs ) = @_;
+
+    my @modified_subs = ();
+    foreach my $sub ( @{$found_subs} ) {
+        if (not $sub->isa('PPI::Statement::Sub')) {
+            my $new_sub = PPI::Statement::Sub->new();
+            my @indices = grep {$sub->{children}[$_] && defined $sub->{children}[$_]{content} && $sub->{children}[$_]{content} eq 'sub'} 0..$#{$sub->{children}};
+            
+            if (defined $indices[0]) {
+                push @{$new_sub->{children}},  @{$sub->{children}}[($indices[0])..$#{$sub->{children}}];
+                my $new_name = $sub->{children}[2]{content};
+                $new_sub->{children}[0]->set_content($new_name);
+                push @modified_subs, $new_sub;
+            }
+        } 
+        else {
+            push @modified_subs, $sub;
+        }
+    }
+
+    return \@modified_subs;
 }
 
 sub measure_sub_metrics {

--- a/script/measureperl
+++ b/script/measureperl
@@ -1,20 +1,24 @@
-#!/usr/bin/perl
+#!/opt/homebrew/opt/perl/bin/perl
 use strict;
 use warnings;
+use lib 'blib/lib';
 use Getopt::Long ();
-use Perl::Metrics::Lite;
+use Perl::Metrics::Lite;  
 use Pod::Usage;
 use Perl::Metrics::Lite::Report::Text;
 
 our $VERSION = "0.092";
 
 my $show_only_error = 0;
+my $only_json = 0;
+
 Getopt::Long::GetOptions(
     'h|help'                        => \my $help,
     'verbose'                       => \my $verbose,
     'l|max_sub_lines=i'             => \my $max_sub_lines,
     'c|max_sub_mccabe_complexity=i' => \my $max_sub_mccabe_complexity,
     'e|show_only_error'             => \$show_only_error,
+    'j|only_json'                   => \$only_json
 ) or pod2usage();
 
 pod2usage() if $help;
@@ -31,7 +35,8 @@ sub report {
     my $reporter = Perl::Metrics::Lite::Report::Text->new(
         max_sub_lines             => $max_sub_lines             || 60,
         max_sub_mccabe_complexity => $max_sub_mccabe_complexity || 10,
-        show_only_error           => $show_only_error
+        show_only_error           => $show_only_error,
+        only_json                 => $only_json || 0,
     );
     my $analzyer = Perl::Metrics::Lite->new( report_module => $reporter );
     my $analysis = $analzyer->analyze_files(@$files);


### PR DESCRIPTION
This PR has number of improvements (unfortunately). It should have been better to split it into multiple PRs... but the amount of changes is not that big.

1. IT can handle the rpc method constructs like rpc get_settings => sub { } or like this rpc "statement",
category => 'account',
sub {
2. generate SARIF file format https://docs.oasis-open.org/sarif/sarif/v2.0/csprd01/sarif-v2.0-csprd01.html
3. disable all output except json based on -j flag